### PR TITLE
KAN-5-Move-Geoid-calculations-to-the-to-currentGpsPositions_-setter

### DIFF
--- a/ros2_ws/src/central_ground_coverage_controller/include/CentralCoverageControllerNode.h
+++ b/ros2_ws/src/central_ground_coverage_controller/include/CentralCoverageControllerNode.h
@@ -31,6 +31,11 @@ private:
     rclcpp::TimerBase::SharedPtr timer_;
 
     /**
+     *  Sets currentGpsPositions_ with altitude accounting for geoid height.
+     */
+    void CentralCoverageControllerNode::setCurrentGpsPosition(const geographic_msgs::msg::GeoPoseStamped& geopose, int uas_id);
+
+    /**
      *  Sets currentGpsPositions_ to the recieved GeoPoseStamped values recieved
      *  from the central_control/uas_{i}/global_pose topic.
      */


### PR DESCRIPTION
Made geoid a class member of the central coverage controller node.
Moved geoid computation to a new setCurrentGpsPosition method.